### PR TITLE
feat(proxy-service): Support raw functions and nested objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 .web-extrc.yml
 /docs/.vitepress/cache
 .DS_Store
+tsconfig.vitest-temp.json

--- a/packages/isolated-element/tsconfig.json
+++ b/packages/isolated-element/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "tsconfig/ts-library.json",
   "compilerOptions": {
     "lib": ["DOM", "ESNext"]
-  }
+  },
+  "exclude": ["lib"]
 }

--- a/packages/messaging/tsconfig.json
+++ b/packages/messaging/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "tsconfig/ts-library.json"
+  "extends": "tsconfig/ts-library.json",
+  "exclude": ["lib"]
 }

--- a/packages/proxy-service/package.json
+++ b/packages/proxy-service/package.json
@@ -48,9 +48,11 @@
   },
   "dependencies": {
     "@webext-core/messaging": "workspace:*",
+    "get-value": "^3.0.1",
     "webextension-polyfill": "^0.10.0"
   },
   "devDependencies": {
+    "@types/get-value": "^3.0.3",
     "@types/webextension-polyfill": "^0.9.1",
     "@vitest/coverage-c8": "^0.24.5",
     "@webext-core/fake-browser": "workspace:*",

--- a/packages/proxy-service/package.json
+++ b/packages/proxy-service/package.json
@@ -43,7 +43,7 @@
     "build": "tsup src/index.ts --clean --out-dir lib --dts --format esm,cjs,iife --global-name webExtCoreProxyService",
     "build:dependencies": "cd ../.. && turbo run build --filter=@webext-core/proxy-service^...",
     "test": "vitest -r src",
-    "test:coverage": "vitest -r src --coverage",
+    "test:coverage": "vitest run -r src --coverage",
     "compile": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/proxy-service/package.json
+++ b/packages/proxy-service/package.json
@@ -44,7 +44,7 @@
     "build:dependencies": "cd ../.. && turbo run build --filter=@webext-core/proxy-service^...",
     "test": "vitest -r src",
     "test:coverage": "vitest run -r src --coverage",
-    "compile": "tsc --noEmit"
+    "compile": "vitest typecheck"
   },
   "dependencies": {
     "@webext-core/messaging": "workspace:*",
@@ -59,7 +59,7 @@
     "tsconfig": "workspace:*",
     "tsup": "^6.4.0",
     "typescript": "^4.8.4",
-    "vitest": "^0.24.5"
+    "vitest": "0.29.2"
   },
   "peerDependencies": {
     "webextension-polyfill": "^0.10.0"

--- a/packages/proxy-service/package.json
+++ b/packages/proxy-service/package.json
@@ -44,7 +44,7 @@
     "build:dependencies": "cd ../.. && turbo run build --filter=@webext-core/proxy-service^...",
     "test": "vitest -r src",
     "test:coverage": "vitest run -r src --coverage",
-    "compile": "vitest typecheck"
+    "compile": "vitest src typecheck"
   },
   "dependencies": {
     "@webext-core/messaging": "workspace:*",

--- a/packages/proxy-service/package.json
+++ b/packages/proxy-service/package.json
@@ -44,7 +44,7 @@
     "build:dependencies": "cd ../.. && turbo run build --filter=@webext-core/proxy-service^...",
     "test": "vitest -r src",
     "test:coverage": "vitest run -r src --coverage",
-    "compile": "vitest src typecheck"
+    "compile": "vitest typecheck"
   },
   "dependencies": {
     "@webext-core/messaging": "workspace:*",

--- a/packages/proxy-service/package.json
+++ b/packages/proxy-service/package.json
@@ -43,8 +43,7 @@
     "build": "tsup src/index.ts --clean --out-dir lib --dts --format esm,cjs,iife --global-name webExtCoreProxyService",
     "build:dependencies": "cd ../.. && turbo run build --filter=@webext-core/proxy-service^...",
     "test": "vitest -r src",
-    "test:types": "vitest typecheck --run",
-    "test:coverage": "vitest run -r src --coverage",
+    "test:coverage": "vitest -r src --coverage",
     "compile": "tsc --noEmit"
   },
   "dependencies": {
@@ -60,7 +59,7 @@
     "tsconfig": "workspace:*",
     "tsup": "^6.4.0",
     "typescript": "^4.8.4",
-    "vitest": "0.29.2"
+    "vitest": "0.28.0"
   },
   "peerDependencies": {
     "webextension-polyfill": "^0.10.0"

--- a/packages/proxy-service/package.json
+++ b/packages/proxy-service/package.json
@@ -43,8 +43,9 @@
     "build": "tsup src/index.ts --clean --out-dir lib --dts --format esm,cjs,iife --global-name webExtCoreProxyService",
     "build:dependencies": "cd ../.. && turbo run build --filter=@webext-core/proxy-service^...",
     "test": "vitest -r src",
+    "test:types": "vitest typecheck --run",
     "test:coverage": "vitest run -r src --coverage",
-    "compile": "vitest typecheck"
+    "compile": "tsc --noEmit"
   },
   "dependencies": {
     "@webext-core/messaging": "workspace:*",

--- a/packages/proxy-service/src/defineProxyService.test.ts
+++ b/packages/proxy-service/src/defineProxyService.test.ts
@@ -12,9 +12,8 @@ const isBackgroundMock = vi.mocked(isBackground);
 
 const defineTestService = () =>
   defineProxyService('TestService', (version: number) => ({
-    getVersion: async () => version,
+    getVersion: () => version,
     getNextVersion: () => Promise.resolve(version + 1),
-    a: '',
   }));
 
 describe('defineProxyService', () => {

--- a/packages/proxy-service/src/defineProxyService.test.ts
+++ b/packages/proxy-service/src/defineProxyService.test.ts
@@ -14,6 +14,7 @@ const defineTestService = () =>
   defineProxyService('TestService', (version: number) => ({
     getVersion: async () => version,
     getNextVersion: () => Promise.resolve(version + 1),
+    a: '',
   }));
 
 describe('defineProxyService', () => {

--- a/packages/proxy-service/src/defineProxyService.test.ts
+++ b/packages/proxy-service/src/defineProxyService.test.ts
@@ -70,20 +70,27 @@ describe('defineProxyService', () => {
     expect(fn).toBeCalledTimes(1);
   });
 
-  it('should support executing deeply nested functions', async () => {
-    const expected = 5;
-    const fn = vi.fn<[], Promise<number>>().mockResolvedValue(expected);
+  it('should support executing deeply nested functions at multiple depths', async () => {
+    const expected1 = 5;
+    const expected2 = 6;
+    const fn1 = vi.fn<[], Promise<number>>().mockResolvedValue(expected1);
+    const fn2 = vi.fn<[], Promise<number>>().mockResolvedValue(expected2);
     const [registerDeepObject, getDeepObject] = defineProxyService('DeepObject', () => ({
-      path: { to: { fn } },
+      fn1,
+      path: {
+        to: {
+          fn2,
+        },
+      },
     }));
     registerDeepObject();
 
     isBackgroundMock.mockReturnValue(false);
     const deepObject = getDeepObject();
 
-    const actual = await deepObject.path.to.fn();
-
-    expect(actual).toBe(expected);
-    expect(fn).toBeCalledTimes(1);
+    await expect(deepObject.fn1()).resolves.toBe(expected1);
+    expect(fn1).toBeCalledTimes(1);
+    await expect(deepObject.path.to.fn2()).resolves.toBe(expected2);
+    expect(fn2).toBeCalledTimes(1);
   });
 });

--- a/packages/proxy-service/src/defineProxyService.test.ts
+++ b/packages/proxy-service/src/defineProxyService.test.ts
@@ -1,6 +1,7 @@
 import { defineProxyService } from './defineProxyService';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { isBackground } from './isBackground';
+import { fakeBrowser } from '@webext-core/fake-browser';
 
 vi.mock('webextension-polyfill');
 
@@ -11,13 +12,14 @@ const isBackgroundMock = vi.mocked(isBackground);
 
 const defineTestService = () =>
   defineProxyService('TestService', (version: number) => ({
-    getVersion: () => version,
+    getVersion: async () => version,
     getNextVersion: () => Promise.resolve(version + 1),
   }));
 
 describe('defineProxyService', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    fakeBrowser.reset();
   });
 
   it("getService should fail to get the service in the background if one hasn't been registered", () => {
@@ -28,25 +30,60 @@ describe('defineProxyService', () => {
   });
 
   it('getService should return a proxy in other contexts', () => {
-    const [_, getTestService] = defineTestService();
+    const [registerTestService, getTestService] = defineTestService();
+    registerTestService(1);
     isBackgroundMock.mockReturnValue(false);
 
-    expect(getTestService()).toEqual({});
+    // @ts-expect-error: __proxy is not apart of the type, but it's there
+    expect(getTestService().__proxy).toEqual(true);
   });
 
   it('should defer execution of the proxy service methods to the real service methods', async () => {
     const version = 10;
     const [registerTestService, getTestService] = defineTestService();
+    registerTestService(version);
+
+    isBackgroundMock.mockReturnValue(true);
+    const real = getTestService();
     isBackgroundMock.mockReturnValue(false);
     const proxy = getTestService();
-    isBackgroundMock.mockReturnValue(true);
-    registerTestService(version);
-    const real = getTestService();
     const realGetVersionSpy = vi.spyOn(real, 'getVersion');
 
     const actual = await proxy.getVersion();
 
     expect(actual).toEqual(version);
     expect(realGetVersionSpy).toBeCalledTimes(1);
+  });
+
+  it('should support executing functions directly', async () => {
+    const expected = 5;
+    const fn: () => Promise<void> = vi.fn().mockResolvedValue(expected);
+    const [registerFn, getFn] = defineProxyService('fn', () => fn);
+    registerFn();
+
+    isBackgroundMock.mockReturnValue(false);
+    const proxyFn = getFn();
+
+    const actual = await proxyFn();
+
+    expect(actual).toBe(expected);
+    expect(fn).toBeCalledTimes(1);
+  });
+
+  it('should support executing deeply nested functions', async () => {
+    const expected = 5;
+    const fn = vi.fn<[], Promise<number>>().mockResolvedValue(expected);
+    const [registerDeepObject, getDeepObject] = defineProxyService('DeepObject', () => ({
+      path: { to: { fn } },
+    }));
+    registerDeepObject();
+
+    isBackgroundMock.mockReturnValue(false);
+    const deepObject = getDeepObject();
+
+    const actual = await deepObject.path.to.fn();
+
+    expect(actual).toBe(expected);
+    expect(fn).toBeCalledTimes(1);
   });
 });

--- a/packages/proxy-service/src/defineProxyService.ts
+++ b/packages/proxy-service/src/defineProxyService.ts
@@ -33,13 +33,13 @@ export function defineProxyService<TService extends Service, TArgs extends any[]
 
       // Executed when accessing a property on an object
       get(target, propertyName, receiver) {
-        if (propertyName === '__proxy') return Reflect.get(target, propertyName, receiver);
-        if (typeof propertyName === 'symbol') return undefined;
-
+        if (propertyName === '__proxy' || typeof propertyName === 'symbol') {
+          return Reflect.get(target, propertyName, receiver);
+        }
         return createProxy(path == null ? propertyName : `${path}.${propertyName}`);
       },
     });
-    // @ts-expect-error: Adding a propert
+    // @ts-expect-error: Adding a hidden property
     proxy.__proxy = true;
     return proxy;
   }
@@ -54,7 +54,7 @@ export function defineProxyService<TService extends Service, TArgs extends any[]
       return service;
     },
 
-    function getService(): DeepAsync<TService> {
+    function getService() {
       // Create proxy for non-background
       if (!isBackground()) return createProxy();
 
@@ -64,8 +64,7 @@ export function defineProxyService<TService extends Service, TArgs extends any[]
           `Failed to get an instance of ${name}: in background, but registerService has not been called. Did you forget to call registerService?`,
         );
       }
-      // @ts-expect-error: DeepAsync<TService> makes some fields type change
-      return service;
+      return service as unknown as DeepAsync<TService>;
     },
   ];
 }

--- a/packages/proxy-service/src/defineProxyService.ts
+++ b/packages/proxy-service/src/defineProxyService.ts
@@ -3,14 +3,11 @@ import { DeepAsync, ProxyServiceConfig, Service } from './types';
 import { defineExtensionMessaging, ProtocolWithReturn } from '@webext-core/messaging';
 import get from 'get-value';
 
-type RegisterService<TService extends Service, TArgs extends any[]> = (...args: TArgs) => TService;
-type GetService<TService extends Service> = () => DeepAsync<TService>;
-
 export function defineProxyService<TService extends Service, TArgs extends any[]>(
   name: string,
   init: (...args: TArgs) => TService,
   config?: ProxyServiceConfig,
-): [registerService: RegisterService<TService, TArgs>, getService: GetService<TService>] {
+): [registerService: (...args: TArgs) => TService, getService: () => DeepAsync<TService>] {
   let service: TService | undefined;
 
   const messageKey = `proxy-service.${name}`;
@@ -67,7 +64,7 @@ export function defineProxyService<TService extends Service, TArgs extends any[]
           `Failed to get an instance of ${name}: in background, but registerService has not been called. Did you forget to call registerService?`,
         );
       }
-      // @ts-expect-error
+      // @ts-expect-error: DeepAsync<TService> makes some fields type change
       return service;
     },
   ];

--- a/packages/proxy-service/src/types.test-d.ts
+++ b/packages/proxy-service/src/types.test-d.ts
@@ -1,0 +1,57 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { defineProxyService } from './defineProxyService';
+
+// https://vitest.dev/guide/testing-types.html
+
+describe('Types', () => {
+  describe('getService', () => {
+    function createService(arg: string) {
+      return {
+        property: 'a',
+        syncFn(arg: string): number {
+          throw Error('Not implemented');
+        },
+        async asyncFn(): Promise<number> {
+          throw Error('Not implemented');
+        },
+      };
+    }
+    const [_, getService] = defineProxyService('test', createService);
+    const service = getService();
+
+    it('should make sync functions async', () => {
+      expectTypeOf(service.syncFn).toEqualTypeOf<(arg: string) => Promise<number>>();
+    });
+
+    it('should not change async functions', () => {
+      expectTypeOf(service.asyncFn).toEqualTypeOf<() => Promise<number>>();
+    });
+
+    it("should make properties never since they can't be accessed synchronously", () => {
+      expectTypeOf(service.property).toBeNever();
+    });
+  });
+
+  describe('registerService', () => {
+    it('should require args when the init function has them', () => {
+      const createService = (arg1: string, arg2: number) => ({});
+      const [registerService] = defineProxyService('test', createService);
+
+      expectTypeOf(registerService).parameters.toEqualTypeOf<[string, number]>();
+    });
+
+    it("should not require args when the init function doesn't have any", () => {
+      const createService = () => ({});
+      const [registerService] = defineProxyService('test', createService);
+
+      expectTypeOf(registerService).parameters.toEqualTypeOf<[]>();
+    });
+
+    it("should return the actual service, not it's deep async version", () => {
+      const createService = () => ({ syncFn: () => {} });
+      const [registerService] = defineProxyService('test', createService);
+
+      expectTypeOf(registerService).returns.toEqualTypeOf<ReturnType<typeof createService>>();
+    });
+  });
+});

--- a/packages/proxy-service/src/types.ts
+++ b/packages/proxy-service/src/types.ts
@@ -2,15 +2,15 @@ import { ExtensionMessagingConfig } from '@webext-core/messaging';
 
 export type Proimsify<T> = T extends Promise<any> ? T : Promise<T>;
 
-export type Service = Record<string, any | ((...args: any[]) => any)>;
+export type AsyncFunction = (...args: any) => Promise<any>;
 
-/**
- * Make all functions of a Service/interface async.
- */
-export type AsyncService<TService> = {
-  [fn in keyof TService]: TService[fn] extends (...args: any[]) => any
-    ? (...args: Parameters<TService[fn]>) => Proimsify<ReturnType<TService[fn]>>
-    : TService[fn];
-};
+// Only support types 5 layers deep.
+export type InputService =
+  | AsyncFunction
+  | Record<string, AsyncFunction>
+  | Record<string, Record<string, AsyncFunction>>
+  | Record<string, Record<string, Record<string, AsyncFunction>>>
+  | Record<string, Record<string, Record<string, Record<string, AsyncFunction>>>>
+  | Record<string, Record<string, Record<string, Record<string, Record<string, AsyncFunction>>>>>;
 
 export interface ProxyServiceConfig extends ExtensionMessagingConfig {}

--- a/packages/proxy-service/src/types.ts
+++ b/packages/proxy-service/src/types.ts
@@ -16,7 +16,7 @@ export type DeepAsync<TService> = TService extends (...args: any) => any
         ? ToAsyncFunction<TService[fn]>
         : TService[fn] extends { [key: string]: any }
         ? DeepAsync<TService[fn]>
-        : TService[fn];
+        : never;
     };
 
 export type Service = ((...args: any[]) => Promise<any>) | { [key: string]: any | Service };

--- a/packages/proxy-service/src/types.ts
+++ b/packages/proxy-service/src/types.ts
@@ -2,15 +2,23 @@ import { ExtensionMessagingConfig } from '@webext-core/messaging';
 
 export type Proimsify<T> = T extends Promise<any> ? T : Promise<T>;
 
-export type AsyncFunction = (...args: any) => Promise<any>;
+type ToAsyncFunction<T extends (...args: any) => any> = (
+  ...args: Parameters<T>
+) => Proimsify<ReturnType<T>>;
 
-// Only support types 5 layers deep.
-export type InputService =
-  | AsyncFunction
-  | Record<string, AsyncFunction>
-  | Record<string, Record<string, AsyncFunction>>
-  | Record<string, Record<string, Record<string, AsyncFunction>>>
-  | Record<string, Record<string, Record<string, Record<string, AsyncFunction>>>>
-  | Record<string, Record<string, Record<string, Record<string, Record<string, AsyncFunction>>>>>;
+/**
+ * Make all functions at all nested levels of an object async
+ */
+export type DeepAsync<TService> = TService extends (...args: any) => any
+  ? ToAsyncFunction<TService>
+  : {
+      [fn in keyof TService]: TService[fn] extends (...args: any[]) => any
+        ? ToAsyncFunction<TService[fn]>
+        : TService[fn] extends { [key: string]: any }
+        ? DeepAsync<TService[fn]>
+        : TService[fn];
+    };
+
+export type Service = ((...args: any[]) => Promise<any>) | { [key: string]: any | Service };
 
 export interface ProxyServiceConfig extends ExtensionMessagingConfig {}

--- a/packages/proxy-service/src/types.ts
+++ b/packages/proxy-service/src/types.ts
@@ -2,9 +2,7 @@ import { ExtensionMessagingConfig } from '@webext-core/messaging';
 
 export type Proimsify<T> = T extends Promise<any> ? T : Promise<T>;
 
-type ToAsyncFunction<T extends (...args: any) => any> = (
-  ...args: Parameters<T>
-) => Proimsify<ReturnType<T>>;
+export type Service = ((...args: any[]) => Promise<any>) | { [key: string]: any | Service };
 
 /**
  * Make all functions at all nested levels of an object async
@@ -19,6 +17,8 @@ export type DeepAsync<TService> = TService extends (...args: any) => any
         : never;
     };
 
-export type Service = ((...args: any[]) => Promise<any>) | { [key: string]: any | Service };
+type ToAsyncFunction<T extends (...args: any) => any> = (
+  ...args: Parameters<T>
+) => Proimsify<ReturnType<T>>;
 
 export interface ProxyServiceConfig extends ExtensionMessagingConfig {}

--- a/packages/proxy-service/tsconfig.json
+++ b/packages/proxy-service/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "tsconfig/ts-library.json",
   "compilerOptions": {
     "lib": ["DOM", "ESNext"]
-  }
+  },
+  "exclude": ["lib"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,10 +105,12 @@ importers:
 
   packages/proxy-service:
     specifiers:
+      '@types/get-value': ^3.0.3
       '@types/webextension-polyfill': ^0.9.1
       '@vitest/coverage-c8': ^0.24.5
       '@webext-core/fake-browser': workspace:*
       '@webext-core/messaging': workspace:*
+      get-value: ^3.0.1
       tsconfig: workspace:*
       tsup: ^6.4.0
       typescript: ^4.8.4
@@ -116,8 +118,10 @@ importers:
       webextension-polyfill: ^0.10.0
     dependencies:
       '@webext-core/messaging': link:../messaging
+      get-value: 3.0.1
       webextension-polyfill: 0.10.0
     devDependencies:
+      '@types/get-value': 3.0.3
       '@types/webextension-polyfill': 0.9.1
       '@vitest/coverage-c8': 0.24.5
       '@webext-core/fake-browser': link:../fake-browser
@@ -766,6 +770,10 @@ packages:
 
   /@types/chai/4.3.3:
     resolution: {integrity: sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==}
+    dev: true
+
+  /@types/get-value/3.0.3:
+    resolution: {integrity: sha512-jsTl/XtZumQfYgn50a0fPkpIyF2xvpsyzZmSLrrwXR8NWiDlw4N5XJiGQYrLckZGGUvbIr920Hz2wqmH1ZfjlQ==}
     dev: true
 
   /@types/http-cache-semantics/4.0.1:
@@ -2675,6 +2683,13 @@ packages:
     resolution: {integrity: sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==}
     dev: true
 
+  /get-value/3.0.1:
+    resolution: {integrity: sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==}
+    engines: {node: '>=6.0'}
+    dependencies:
+      isobject: 3.0.1
+    dev: false
+
   /getpass/0.1.7:
     resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
     dependencies:
@@ -3122,6 +3137,11 @@ packages:
   /isexe/2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
+
+  /isobject/3.0.1:
+    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /isstream/0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,7 +114,7 @@ importers:
       tsconfig: workspace:*
       tsup: ^6.4.0
       typescript: ^4.8.4
-      vitest: ^0.29.2
+      vitest: 0.29.2
       webextension-polyfill: ^0.10.0
     dependencies:
       '@webext-core/messaging': link:../messaging
@@ -1520,7 +1520,7 @@ packages:
       check-error: 1.0.2
       deep-eql: 4.1.3
       get-func-name: 2.0.0
-      loupe: 2.3.5
+      loupe: 2.3.6
       pathval: 1.1.1
       type-detect: 4.0.8
     dev: true
@@ -5538,7 +5538,7 @@ packages:
       '@vitest/runner': 0.29.2
       '@vitest/spy': 0.29.2
       '@vitest/utils': 0.29.2
-      acorn: 8.8.1
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,7 +114,7 @@ importers:
       tsconfig: workspace:*
       tsup: ^6.4.0
       typescript: ^4.8.4
-      vitest: 0.29.2
+      vitest: 0.28.0
       webextension-polyfill: ^0.10.0
     dependencies:
       '@webext-core/messaging': link:../messaging
@@ -128,7 +128,7 @@ importers:
       tsconfig: link:../tsconfig
       tsup: 6.4.0_typescript@4.8.4
       typescript: 4.8.4
-      vitest: 0.29.2
+      vitest: 0.28.0
 
   packages/proxy-service-demo:
     specifiers:
@@ -736,6 +736,10 @@ packages:
       config-chain: 1.1.13
     dev: true
 
+  /@polka/url/1.0.0-next.21:
+    resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
+    dev: true
+
   /@sindresorhus/is/5.3.0:
     resolution: {integrity: sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==}
     engines: {node: '>=14.16'}
@@ -873,30 +877,40 @@ packages:
       - terser
     dev: true
 
-  /@vitest/expect/0.29.2:
-    resolution: {integrity: sha512-wjrdHB2ANTch3XKRhjWZN0UueFocH0cQbi2tR5Jtq60Nb3YOSmakjdAvUa2JFBu/o8Vjhj5cYbcMXkZxn1NzmA==}
+  /@vitest/expect/0.28.0:
+    resolution: {integrity: sha512-GSk1k9/W8JcVHFhCqVX/MdV9SbVbOV4p7U293f7f9xpNK17c1oA47OErsdL0a5lwJoS82RT4ZieTuE1Q9egeaQ==}
     dependencies:
-      '@vitest/spy': 0.29.2
-      '@vitest/utils': 0.29.2
+      '@vitest/spy': 0.28.0
+      '@vitest/utils': 0.28.0
       chai: 4.3.7
     dev: true
 
-  /@vitest/runner/0.29.2:
-    resolution: {integrity: sha512-A1P65f5+6ru36AyHWORhuQBJrOOcmDuhzl5RsaMNFe2jEkoj0faEszQS4CtPU/LxUYVIazlUtZTY0OEZmyZBnA==}
+  /@vitest/runner/0.28.0:
+    resolution: {integrity: sha512-SXQO9aubp7Hg4DV4D5DP70wJ/4o0krH1gAPrSt+rhEZQbQvMaBJAHWOxEibwzLkklgoHreaMEvETFILkGQWXww==}
     dependencies:
-      '@vitest/utils': 0.29.2
+      '@vitest/utils': 0.28.0
       p-limit: 4.0.0
       pathe: 1.1.0
     dev: true
 
-  /@vitest/spy/0.29.2:
-    resolution: {integrity: sha512-Hc44ft5kaAytlGL2PyFwdAsufjbdOvHklwjNy/gy/saRbg9Kfkxfh+PklLm1H2Ib/p586RkQeNFKYuJInUssyw==}
+  /@vitest/spy/0.28.0:
+    resolution: {integrity: sha512-gYBDQIP0QDvxrscl2Id0BTbzLUbuAzFiFur3eHxH9Yt5cM6YCH/kxBrSHhmXTbu92UenLx53Gwq17u5N0zGNDQ==}
     dependencies:
       tinyspy: 1.0.2
     dev: true
 
-  /@vitest/utils/0.29.2:
-    resolution: {integrity: sha512-F14/Uc+vCdclStS2KEoXJlOLAEyqRhnw0gM27iXw9bMTcyKRPJrQ+rlC6XZ125GIPvvKYMPpVxNhiou6PsEeYQ==}
+  /@vitest/ui/0.28.0:
+    resolution: {integrity: sha512-ihcVEx8t1gZXMboPGcIvoHk+PxiW5USxDMqnZOeUVIUm+XrRCtoJ96YDXdeR6MyPWeYLBPXfBWSxp5gMqoNSkw==}
+    dependencies:
+      fast-glob: 3.2.12
+      flatted: 3.2.7
+      pathe: 1.1.0
+      picocolors: 1.0.0
+      sirv: 2.0.2
+    dev: true
+
+  /@vitest/utils/0.28.0:
+    resolution: {integrity: sha512-Dt+jDZbwriZWzJ5Hi9nAUnz9IPgNb+ACE96tWiXPp/u9NmCYWIWcuNoUOYS8HQyGFz31GiNYGvaZ4ZEDjAgi1g==}
     dependencies:
       cli-truncate: 3.1.0
       diff: 5.1.0
@@ -3719,6 +3733,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /mrmime/1.0.1:
+    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
+    engines: {node: '>=10'}
+    dev: true
+
   /ms/2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
     dev: true
@@ -4599,6 +4618,15 @@ packages:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
 
+  /sirv/2.0.2:
+    resolution: {integrity: sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==}
+    engines: {node: '>= 10'}
+    dependencies:
+      '@polka/url': 1.0.0-next.21
+      mrmime: 1.0.1
+      totalist: 3.0.0
+    dev: true
+
   /slash/3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -4908,6 +4936,11 @@ packages:
   /tosource/1.0.0:
     resolution: {integrity: sha512-N6g8eQ1eerw6Y1pBhdgkubWIiPFwXa2POSUrlL8jth5CyyEWNWzoGKRkO3CaO7Jx27hlJP54muB3btIAbx4MPg==}
     engines: {node: '>=0.4.0'}
+    dev: true
+
+  /totalist/3.0.0:
+    resolution: {integrity: sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==}
+    engines: {node: '>=6'}
     dev: true
 
   /tough-cookie/2.5.0:
@@ -5222,8 +5255,8 @@ packages:
       extsprintf: 1.3.0
     dev: true
 
-  /vite-node/0.29.2_@types+node@18.11.9:
-    resolution: {integrity: sha512-5oe1z6wzI3gkvc4yOBbDBbgpiWiApvuN4P55E8OI131JGrSuo4X3SOZrNmZYo4R8Zkze/dhi572blX0zc+6SdA==}
+  /vite-node/0.28.0_@types+node@18.11.9:
+    resolution: {integrity: sha512-4w+hFGfAfsfCchVpZFkIEEEGxF+OA1lVIPc7Dijf/k/nJRUGU80RWnDubA0jmc7CApg/UbnSkIsYGh8v4eJ1HA==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     dependencies:
@@ -5232,6 +5265,8 @@ packages:
       mlly: 1.1.1
       pathe: 1.1.0
       picocolors: 1.0.0
+      source-map: 0.6.1
+      source-map-support: 0.5.21
       vite: 4.0.4_@types+node@18.11.9
     transitivePeerDependencies:
       - '@types/node'
@@ -5509,14 +5544,13 @@ packages:
       - terser
     dev: true
 
-  /vitest/0.29.2:
-    resolution: {integrity: sha512-ydK9IGbAvoY8wkg29DQ4ivcVviCaUi3ivuPKfZEVddMTenFHUfB8EEDXQV8+RasEk1ACFLgMUqAaDuQ/Nk+mQA==}
+  /vitest/0.28.0:
+    resolution: {integrity: sha512-qgPw3vHEOc36wJBknmmeWIpuaLnXtWZinkeT8aOTyIuBYipgpabVzWjWgCilKDa8F+ZrY2cHeH2xGUCYOc5/XA==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@vitest/browser': '*'
-      '@vitest/ui': '*'
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -5534,10 +5568,11 @@ packages:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
       '@types/node': 18.11.9
-      '@vitest/expect': 0.29.2
-      '@vitest/runner': 0.29.2
-      '@vitest/spy': 0.29.2
-      '@vitest/utils': 0.29.2
+      '@vitest/expect': 0.28.0
+      '@vitest/runner': 0.28.0
+      '@vitest/spy': 0.28.0
+      '@vitest/ui': 0.28.0
+      '@vitest/utils': 0.28.0
       acorn: 8.8.2
       acorn-walk: 8.2.0
       cac: 6.7.14
@@ -5553,7 +5588,7 @@ packages:
       tinypool: 0.3.1
       tinyspy: 1.0.2
       vite: 4.0.4_@types+node@18.11.9
-      vite-node: 0.29.2_@types+node@18.11.9
+      vite-node: 0.28.0_@types+node@18.11.9
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,7 +114,7 @@ importers:
       tsconfig: workspace:*
       tsup: ^6.4.0
       typescript: ^4.8.4
-      vitest: ^0.24.5
+      vitest: ^0.29.2
       webextension-polyfill: ^0.10.0
     dependencies:
       '@webext-core/messaging': link:../messaging
@@ -128,7 +128,7 @@ importers:
       tsconfig: link:../tsconfig
       tsup: 6.4.0_typescript@4.8.4
       typescript: 4.8.4
-      vitest: 0.24.5
+      vitest: 0.29.2
 
   packages/proxy-service-demo:
     specifiers:
@@ -772,6 +772,10 @@ packages:
     resolution: {integrity: sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==}
     dev: true
 
+  /@types/chai/4.3.4:
+    resolution: {integrity: sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==}
+    dev: true
+
   /@types/get-value/3.0.3:
     resolution: {integrity: sha512-jsTl/XtZumQfYgn50a0fPkpIyF2xvpsyzZmSLrrwXR8NWiDlw4N5XJiGQYrLckZGGUvbIr920Hz2wqmH1ZfjlQ==}
     dev: true
@@ -867,6 +871,38 @@ packages:
       - sugarss
       - supports-color
       - terser
+    dev: true
+
+  /@vitest/expect/0.29.2:
+    resolution: {integrity: sha512-wjrdHB2ANTch3XKRhjWZN0UueFocH0cQbi2tR5Jtq60Nb3YOSmakjdAvUa2JFBu/o8Vjhj5cYbcMXkZxn1NzmA==}
+    dependencies:
+      '@vitest/spy': 0.29.2
+      '@vitest/utils': 0.29.2
+      chai: 4.3.7
+    dev: true
+
+  /@vitest/runner/0.29.2:
+    resolution: {integrity: sha512-A1P65f5+6ru36AyHWORhuQBJrOOcmDuhzl5RsaMNFe2jEkoj0faEszQS4CtPU/LxUYVIazlUtZTY0OEZmyZBnA==}
+    dependencies:
+      '@vitest/utils': 0.29.2
+      p-limit: 4.0.0
+      pathe: 1.1.0
+    dev: true
+
+  /@vitest/spy/0.29.2:
+    resolution: {integrity: sha512-Hc44ft5kaAytlGL2PyFwdAsufjbdOvHklwjNy/gy/saRbg9Kfkxfh+PklLm1H2Ib/p586RkQeNFKYuJInUssyw==}
+    dependencies:
+      tinyspy: 1.0.2
+    dev: true
+
+  /@vitest/utils/0.29.2:
+    resolution: {integrity: sha512-F14/Uc+vCdclStS2KEoXJlOLAEyqRhnw0gM27iXw9bMTcyKRPJrQ+rlC6XZ125GIPvvKYMPpVxNhiou6PsEeYQ==}
+    dependencies:
+      cli-truncate: 3.1.0
+      diff: 5.1.0
+      loupe: 2.3.6
+      picocolors: 1.0.0
+      pretty-format: 27.5.1
     dev: true
 
   /@vue/compiler-core/3.2.47:
@@ -1018,6 +1054,12 @@ packages:
 
   /acorn/8.8.1:
     resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /acorn/8.8.2:
+    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -1198,6 +1240,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+    dev: true
+
+  /ansi-styles/5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
     dev: true
 
   /ansi-styles/6.2.1:
@@ -1465,6 +1512,19 @@ packages:
       type-detect: 4.0.8
     dev: true
 
+  /chai/4.3.7:
+    resolution: {integrity: sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==}
+    engines: {node: '>=4'}
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.2
+      deep-eql: 4.1.3
+      get-func-name: 2.0.0
+      loupe: 2.3.5
+      pathval: 1.1.1
+      type-detect: 4.0.8
+    dev: true
+
   /chalk/2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -1563,6 +1623,14 @@ packages:
   /cli-boxes/3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
+    dev: true
+
+  /cli-truncate/3.1.0:
+    resolution: {integrity: sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 5.1.2
     dev: true
 
   /cliui/7.0.4:
@@ -1834,6 +1902,13 @@ packages:
       type-detect: 4.0.8
     dev: true
 
+  /deep-eql/4.1.3:
+    resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
+    engines: {node: '>=6'}
+    dependencies:
+      type-detect: 4.0.8
+    dev: true
+
   /deep-extend/0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -1873,6 +1948,11 @@ packages:
   /delayed-stream/1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+    dev: true
+
+  /diff/5.1.0:
+    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
+    engines: {node: '>=0.3.1'}
     dev: true
 
   /dir-glob/3.0.1:
@@ -3053,6 +3133,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /is-fullwidth-code-point/4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
+    dev: true
+
   /is-glob/4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -3476,6 +3561,12 @@ packages:
       get-func-name: 2.0.0
     dev: true
 
+  /loupe/2.3.6:
+    resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
+    dependencies:
+      get-func-name: 2.0.0
+    dev: true
+
   /lowercase-keys/3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3606,6 +3697,15 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
+    dev: true
+
+  /mlly/1.1.1:
+    resolution: {integrity: sha512-Jnlh4W/aI4GySPo6+DyTN17Q75KKbLTyFK8BrGhjNP4rxuUjbRWhE6gHg3bs33URWAF44FRm7gdQA348i3XxRw==}
+    dependencies:
+      acorn: 8.8.2
+      pathe: 1.1.0
+      pkg-types: 1.0.2
+      ufo: 1.1.1
     dev: true
 
   /moment/2.29.4:
@@ -3847,6 +3947,13 @@ packages:
       yocto-queue: 0.1.0
     dev: true
 
+  /p-limit/4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      yocto-queue: 1.0.0
+    dev: true
+
   /p-locate/4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -3948,6 +4055,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /pathe/1.1.0:
+    resolution: {integrity: sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==}
+    dev: true
+
   /pathval/1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
@@ -4002,6 +4113,14 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
+  /pkg-types/1.0.2:
+    resolution: {integrity: sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==}
+    dependencies:
+      jsonc-parser: 3.2.0
+      mlly: 1.1.1
+      pathe: 1.1.0
+    dev: true
+
   /postcss-load-config/3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
@@ -4054,6 +4173,15 @@ packages:
     resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+    dev: true
+
+  /pretty-format/27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
     dev: true
 
   /pretty-quick/3.1.3_prettier@2.7.1:
@@ -4155,6 +4283,10 @@ packages:
       ini: 1.3.8
       minimist: 1.2.7
       strip-json-comments: 2.0.1
+    dev: true
+
+  /react-is/17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: true
 
   /readable-stream/2.3.7:
@@ -4444,6 +4576,10 @@ packages:
       vscode-textmate: 8.0.0
     dev: true
 
+  /siginfo/2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
   /sign-addon/5.1.0:
     resolution: {integrity: sha512-fag/csbsw25WpW+G+uWE6rRImSjlfwQNjuP28fFhvXpfW+kXccxl/o1QEW+hXtTidwpysksb7Y0B8UCeMkYkSA==}
     dependencies:
@@ -4466,6 +4602,14 @@ packages:
   /slash/3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+    dev: true
+
+  /slice-ansi/5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 4.0.0
     dev: true
 
   /sonic-boom/3.2.0:
@@ -4536,6 +4680,14 @@ packages:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
+    dev: true
+
+  /stackback/0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
+  /std-env/3.3.2:
+    resolution: {integrity: sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA==}
     dev: true
 
   /stream-to-array/2.3.0:
@@ -4637,6 +4789,12 @@ packages:
       acorn: 8.8.1
     dev: true
 
+  /strip-literal/1.0.1:
+    resolution: {integrity: sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==}
+    dependencies:
+      acorn: 8.8.2
+    dev: true
+
   /sucrase/3.28.0:
     resolution: {integrity: sha512-TK9600YInjuiIhVM3729rH4ZKPOsGeyXUwY+Ugu9eilNbdTFyHr6XcAGYbRVZPDgWj6tgI7bx95aaJjHnbffag==}
     engines: {node: '>=8'}
@@ -4715,6 +4873,11 @@ packages:
 
   /tinypool/0.3.0:
     resolution: {integrity: sha512-NX5KeqHOBZU6Bc0xj9Vr5Szbb1j8tUHIeD18s41aDJaPeC5QTdEhK0SpdpUrZlj2nv5cctNcSjaKNanXlfcVEQ==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinypool/0.3.1:
+    resolution: {integrity: sha512-zLA1ZXlstbU2rlpA4CIeVaqvWq41MTWqLY3FfsAXgC8+f7Pk7zroaJQxDgxn1xNudKW6Kmj4808rPFShUlIRmQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -4962,6 +5125,10 @@ packages:
     hasBin: true
     dev: true
 
+  /ufo/1.1.1:
+    resolution: {integrity: sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==}
+    dev: true
+
   /unique-string/3.0.0:
     resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
     engines: {node: '>=12'}
@@ -5053,6 +5220,27 @@ packages:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
       extsprintf: 1.3.0
+    dev: true
+
+  /vite-node/0.29.2_@types+node@18.11.9:
+    resolution: {integrity: sha512-5oe1z6wzI3gkvc4yOBbDBbgpiWiApvuN4P55E8OI131JGrSuo4X3SOZrNmZYo4R8Zkze/dhi572blX0zc+6SdA==}
+    engines: {node: '>=v14.16.0'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      mlly: 1.1.1
+      pathe: 1.1.0
+      picocolors: 1.0.0
+      vite: 4.0.4_@types+node@18.11.9
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: true
 
   /vite-plugin-web-extension/2.0.0-alpha5_vite@3.2.4:
@@ -5175,6 +5363,40 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /vite/4.0.4_@types+node@18.11.9:
+    resolution: {integrity: sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.11.9
+      esbuild: 0.16.15
+      postcss: 8.4.21
+      resolve: 1.22.1
+      rollup: 3.9.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /vitepress/1.0.0-alpha.45:
     resolution: {integrity: sha512-8AVWdymQqBUPmXmAbpapDDg18iDmkNJ47l5eOklBlAjj3n8P3zDAsBhOWSQ6+Nvm6+/GaZATyAvsrg47JD5Idw==}
     hasBin: true
@@ -5278,6 +5500,61 @@ packages:
       tinypool: 0.3.0
       tinyspy: 1.0.2
       vite: 3.2.2
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest/0.29.2:
+    resolution: {integrity: sha512-ydK9IGbAvoY8wkg29DQ4ivcVviCaUi3ivuPKfZEVddMTenFHUfB8EEDXQV8+RasEk1ACFLgMUqAaDuQ/Nk+mQA==}
+    engines: {node: '>=v14.16.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.4
+      '@types/chai-subset': 1.3.3
+      '@types/node': 18.11.9
+      '@vitest/expect': 0.29.2
+      '@vitest/runner': 0.29.2
+      '@vitest/spy': 0.29.2
+      '@vitest/utils': 0.29.2
+      acorn: 8.8.1
+      acorn-walk: 8.2.0
+      cac: 6.7.14
+      chai: 4.3.7
+      debug: 4.3.4
+      local-pkg: 0.4.2
+      pathe: 1.1.0
+      picocolors: 1.0.0
+      source-map: 0.6.1
+      std-env: 3.3.2
+      strip-literal: 1.0.1
+      tinybench: 2.3.1
+      tinypool: 0.3.1
+      tinyspy: 1.0.2
+      vite: 4.0.4_@types+node@18.11.9
+      vite-node: 0.29.2_@types+node@18.11.9
+      why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
       - sass
@@ -5452,6 +5729,15 @@ packages:
       isexe: 2.0.0
     dev: true
 
+  /why-is-node-running/2.2.2:
+    resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+    dev: true
+
   /widest-line/4.0.1:
     resolution: {integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==}
     engines: {node: '>=12'}
@@ -5612,6 +5898,11 @@ packages:
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yocto-queue/1.0.0:
+    resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
+    engines: {node: '>=12.20'}
     dev: true
 
   /zip-dir/2.0.0:


### PR DESCRIPTION
This closes #15.

The proxy service package now supports objects and functions at any depth:

```ts
defineProxyService("getOne", () => async () => 1);

defineProxyService("NumberService", () => ({
  getOne: async () => 1,
}));

defineProxyService("API", () => ({
  numberService: {
    getOne: async () => 1,
  },
}));
```