### PR TITLE
feat(messaging): Simplify protocol map definitions with function types

### DIFF
--- a/packages/messaging/src/index.test-d.ts
+++ b/packages/messaging/src/index.test-d.ts
@@ -39,9 +39,45 @@ describe('Messenger Typing', () => {
     expectTypeOf(onMessage).parameter(1).returns.resolves.toBeBoolean();
   });
 
+  it('should infer data and return types from bound function declaration', () => {
+    const { sendMessage, onMessage } = defineExtensionMessaging<{
+      getStringLength(data: string): number;
+    }>();
+
+    expectTypeOf(sendMessage).parameter(0).toMatchTypeOf<'getStringLength'>();
+    expectTypeOf(sendMessage).parameter(1).toBeString();
+    expectTypeOf(sendMessage).returns.resolves.toBeNumber();
+
+    expectTypeOf(onMessage).parameter(1).parameter(0).toHaveProperty('data').toBeString();
+    expectTypeOf(onMessage).parameter(1).returns.resolves.toBeNumber();
+  });
+
+  it('should infer data and return types from anonymous function declaration', () => {
+    const { sendMessage, onMessage } = defineExtensionMessaging<{
+      getStringLength: (data: string) => number;
+    }>();
+
+    expectTypeOf(sendMessage).parameter(0).toMatchTypeOf<'getStringLength'>();
+    expectTypeOf(sendMessage).parameter(1).toBeString();
+    expectTypeOf(sendMessage).returns.resolves.toBeNumber();
+
+    expectTypeOf(onMessage).parameter(1).parameter(0).toHaveProperty('data').toBeString();
+    expectTypeOf(onMessage).parameter(1).returns.resolves.toBeNumber();
+  });
+
   it('should require passing undefined to sendMessage when there is no data', () => {
     const { sendMessage } = defineExtensionMessaging<{
       ping: ProtocolWithReturn<undefined, 'pong'>;
+    }>();
+
+    expectTypeOf(sendMessage).parameter(0).toMatchTypeOf<'ping'>();
+    expectTypeOf(sendMessage).parameter(1).toBeUndefined();
+    expectTypeOf(sendMessage).parameter(2).toEqualTypeOf<number | undefined>();
+  });
+
+  it('should require passing undefined to sendMessage when there is no arguments in a function definition', () => {
+    const { sendMessage } = defineExtensionMessaging<{
+      ping(): 'pong';
     }>();
 
     expectTypeOf(sendMessage).parameter(0).toMatchTypeOf<'ping'>();

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -37,12 +37,22 @@ export type ProtocolWithReturn<TData, TReturn> = { BtVgCTPYZu: TData; RrhVseLgZW
 /**
  * Given a `ProtocolWithReturn` or a value, return the message's data type.
  */
-export type GetDataType<T> = T extends ProtocolWithReturn<any, any> ? T['BtVgCTPYZu'] : T;
+export type GetDataType<T> = T extends (...args: infer Args) => any
+  ? Parameters<T>['length'] extends 0
+    ? undefined
+    : Args[0]
+  : T extends ProtocolWithReturn<any, any>
+  ? T['BtVgCTPYZu']
+  : T;
 
 /**
  * Given a `ProtocolWithReturn` or a value, return the message's return type.
  */
-export type GetReturnType<T> = T extends ProtocolWithReturn<any, any> ? T['RrhVseLgZW'] : void;
+export type GetReturnType<T> = T extends (...args: any[]) => infer R
+  ? R
+  : T extends ProtocolWithReturn<any, any>
+  ? T['RrhVseLgZW']
+  : void;
 
 /**
  * Either a Promise of a type, or that type directly. Used to indicate that a method can by sync or

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -35,7 +35,7 @@ export interface ExtensionMessagingConfig {
 export type ProtocolWithReturn<TData, TReturn> = { BtVgCTPYZu: TData; RrhVseLgZW: TReturn };
 
 /**
- * Given a `ProtocolWithReturn` or a value, return the message's data type.
+ * Given a function declaration, `ProtocolWithReturn`, or a value, return the message's data type.
  */
 export type GetDataType<T> = T extends (...args: infer Args) => any
   ? Args['length'] extends 0 | 1
@@ -46,7 +46,7 @@ export type GetDataType<T> = T extends (...args: infer Args) => any
   : T;
 
 /**
- * Given a `ProtocolWithReturn` or a value, return the message's return type.
+ * Given a function declaration, `ProtocolWithReturn`, or a value, return the message's return type.
  */
 export type GetReturnType<T> = T extends (...args: any[]) => infer R
   ? R

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -38,9 +38,9 @@ export type ProtocolWithReturn<TData, TReturn> = { BtVgCTPYZu: TData; RrhVseLgZW
  * Given a `ProtocolWithReturn` or a value, return the message's data type.
  */
 export type GetDataType<T> = T extends (...args: infer Args) => any
-  ? Parameters<T>['length'] extends 0
-    ? undefined
-    : Args[0]
+  ? Args['length'] extends 0 | 1
+    ? Args[0]
+    : never
   : T extends ProtocolWithReturn<any, any>
   ? T['BtVgCTPYZu']
   : T;


### PR DESCRIPTION
Added usage of the "infer" builtin typescript type, to allow easier and prettier type-mapping.
Addresses [issue #20](https://github.com/aklinker1/webext-core/issues/20#issue-1629061955)