### PR TITLE
docs: Add links to symbols

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vitepress';
-import { typescriptDocs } from './plugins/typescript-docs';
+import { defineTypescriptDocs } from './plugins/typescript-docs';
 
 const ogDescription = 'Next Generation Frontend Tooling';
 const ogTitle = 'Web Ext Core';
@@ -93,17 +93,10 @@ const apiItemGroup = {
 };
 
 export default defineConfig({
+  ...defineTypescriptDocs(packageDirnames),
+
   title: `Web Ext Core`,
   description: 'Web Extension Development Made Easy',
-
-  ignoreDeadLinks: [/^\/api\/.*/],
-
-  vite: {
-    plugins: [typescriptDocs()],
-    define: {
-      __PACKAGES__: JSON.stringify(packageDirnames),
-    },
-  },
 
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }],

--- a/docs/.vitepress/plugins/typescript-docs.ts
+++ b/docs/.vitepress/plugins/typescript-docs.ts
@@ -95,7 +95,6 @@ export function defineTypescriptDocs(packageDirnames: string[]) {
 
           const a = createLink(symbolName, thisPkg, packages);
           a.style.textDecoration = 'underline';
-          console.log(block.innerHTML, '->', a.outerHTML);
           block.innerHTML = block.innerHTML.replace(symbolName, a.outerHTML);
         }),
       );

--- a/docs/.vitepress/plugins/typescript-docs.ts
+++ b/docs/.vitepress/plugins/typescript-docs.ts
@@ -5,6 +5,105 @@ import { Listr, ListrTask, ListrTaskWrapper } from 'listr2';
 import { Project, Symbol, SourceFile, Node, ts, JSDocableNode, JSDoc } from 'ts-morph';
 import * as prettier from 'prettier';
 import chokidar from 'chokidar';
+import { defineConfig } from 'vitepress';
+import { parseHTML } from 'linkedom';
+
+export function defineTypescriptDocs(packageDirnames: string[]) {
+  const ctx: Ctx = {
+    watchers: [],
+    symbolMap: {},
+  };
+
+  function plugin(): Plugin {
+    let mode: 'build' | 'serve';
+    let hasGenerated = false;
+
+    return {
+      name: 'generate-ts-docs',
+      configResolved(config) {
+        mode = config.command;
+      },
+      async buildStart() {
+        if (hasGenerated) return;
+        hasGenerated = true;
+
+        const allPackages = await getPackages();
+        await generateAll(ctx, allPackages, mode, mode === 'serve');
+      },
+      async buildEnd() {
+        removeWatchListeners(ctx);
+      },
+    };
+  }
+
+  return defineConfig({
+    ignoreDeadLinks: [/^\/api\/.*/],
+
+    vite: {
+      plugins: [plugin()],
+      define: {
+        __PACKAGES__: JSON.stringify(packageDirnames),
+      },
+    },
+
+    transformHtml(code, id) {
+      const [_, thisPkg] = id.match(/\/api\/(.*)\.html$/) ?? [];
+      if (!thisPkg) return;
+
+      const { document } = parseHTML(code);
+      /**
+       * Creates an anchor element to a symbol's package.
+       */
+      const createLink = (
+        symbolName: string,
+        thisPkg: string,
+        packages: string[],
+      ): HTMLAnchorElement => {
+        const a = document.createElement('a');
+        a.textContent = symbolName;
+        if (packages.includes(thisPkg)) {
+          a.href = '#' + symbolName.toLowerCase();
+        } else {
+          a.href = `/api/${packages[0]}#${symbolName.toLowerCase()}`;
+        }
+        return a;
+      };
+
+      // Code blocks - same text color, underlined
+      document.querySelectorAll('pre span').forEach(span => {
+        Object.entries(ctx.symbolMap).forEach(([symbolName, packages]) => {
+          if (span.textContent !== symbolName) return;
+
+          const a = createLink(symbolName, thisPkg, packages);
+          a.style.color = 'inherit';
+          a.style.textDecoration = 'underline';
+          span.replaceChildren(a);
+        });
+      });
+
+      // Inline code - primary color, underlined links
+      document.querySelectorAll('p code, li code').forEach(block =>
+        Object.entries(ctx.symbolMap).forEach(([symbolName, packages]) => {
+          // Look for matching full word
+          if (
+            !block.textContent
+              ?.replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, '')
+              .split(/\s+/)
+              .includes(symbolName)
+          )
+            return;
+
+          const a = createLink(symbolName, thisPkg, packages);
+          a.style.textDecoration = 'underline';
+          console.log(block.innerHTML, '->', a.outerHTML);
+          block.innerHTML = block.innerHTML.replace(symbolName, a.outerHTML);
+        }),
+      );
+
+      return document.toString();
+    },
+  });
+}
 
 type Plugin = NonNullable<NonNullable<UserConfig['vite']>['plugins']>[0];
 type SymbolLinks = { [symbolName: string]: string };
@@ -25,28 +124,6 @@ const EXCLUDED_SYMBOLS = [
   'TData',
   'TReturn',
 ];
-
-export function typescriptDocs(): Plugin {
-  const ctx: Ctx = {
-    watchers: [],
-    symbolMap: {},
-  };
-  let mode: 'build' | 'serve';
-
-  return {
-    name: 'typescript-docs',
-    configResolved(config) {
-      mode = config.command;
-    },
-    async buildStart() {
-      const allPackages = await getPackages();
-      await generateAll(ctx, allPackages, mode, mode === 'serve');
-    },
-    async buildEnd() {
-      removeWatchListeners(ctx);
-    },
-  };
-}
 
 /**
  * context passed into each task

--- a/docs/api/job-scheduler.md
+++ b/docs/api/job-scheduler.md
@@ -75,7 +75,7 @@ interface IntervalJob {
 }
 ```
 
-A job that executes on a set interval, starting when the job is scheduled.
+A job that executes on a set interval, starting when the job is scheduled for the first time.
 
 ### Properties 
 
@@ -84,11 +84,10 @@ A job that executes on a set interval, starting when the job is scheduled.
 - ***`type: 'interval'`***
 
 - ***`duration: number`***<br/>Interval in milliseconds. Due to limitations of the alarms API, it must be greater than 1
-minute and it will be rounded to the nearest minute.
+minute.
 
 - ***`immediate?: boolean`*** (default: `false`)<br/>Execute the job immediately when it is scheduled for the first time. If `false`, it will
-execute for the first time after `durationInMs`. This has no effect when updating an existing
-job.
+execute for the first time after `duration`. This has no effect when updating an existing job.
 
 - ***`execute: ExecuteFn`***
 
@@ -123,7 +122,7 @@ interface JobSchedulerConfig {
 }
 ```
 
-Cofnigure how the messenger behaves.
+Configures how the job scheduler behaves.
 
 ### Properties 
 

--- a/docs/api/messaging.md
+++ b/docs/api/messaging.md
@@ -32,7 +32,7 @@ interface ExtensionMessagingConfig {
 }
 ```
 
-Cofnigure how the messenger behaves.
+Configure how the messenger behaves.
 
 ### Properties 
 
@@ -110,7 +110,7 @@ Unlike the regular `chrome.runtime` messaging APIs, there are no limitations to 
 ## `ProtocolWithReturn`
 
 :::danger Deprecated
-Use the function syntax instead: <https://webext-core.aklinker1.io/messaging/protocol-maps.html#syntax>
+Use the function syntax instead: <https://webext-core.aklinker1.io/guide/messaging/protocol-maps.html#syntax>
 :::
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "docs:build": "vitepress build docs",
     "docs:serve": "vitepress serve docs",
     "docs:test": "vitest -r docs",
-    "docs:generate": "typedoc --plugin typedoc-plugin-markdown",
     "build": "turbo run build",
     "prepare": "husky install"
   },
@@ -28,5 +27,8 @@
     "vitepress": "1.0.0-alpha.75",
     "vitest": "^0.29.2",
     "webextension-polyfill": "^0.10.0"
+  },
+  "dependencies": {
+    "linkedom": "^0.14.26"
   }
 }

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -27,7 +27,7 @@ export interface ExtensionMessagingConfig {
  *
  * > Internally, this is just an object with random keys for the data and return types.
  *
- * @deprecated Use the function syntax instead: <https://webext-core.aklinker1.io/messaging/protocol-maps.html#syntax>
+ * @deprecated Use the function syntax instead: <https://webext-core.aklinker1.io/guide/messaging/protocol-maps.html#syntax>
  *
  * @example
  * interface ProtocolMap {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ importers:
       '@webext-core/fake-browser': workspace:*
       chokidar: ^3.5.3
       husky: ^8.0.1
+      linkedom: ^0.14.26
       listr2: ^6.4.2
       prettier: ^2.7.1
       pretty-quick: ^3.1.3
@@ -19,6 +20,8 @@ importers:
       vitepress: 1.0.0-alpha.75
       vitest: ^0.29.2
       webextension-polyfill: ^0.10.0
+    dependencies:
+      linkedom: 0.14.26
     devDependencies:
       '@aklinker1/generate-changelog': 1.0.0
       '@algolia/client-search': 4.17.0
@@ -1739,7 +1742,6 @@ packages:
 
   /boolbase/1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-    dev: true
 
   /boxen/7.0.0:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
@@ -2195,12 +2197,10 @@ packages:
       domhandler: 5.0.3
       domutils: 3.0.1
       nth-check: 2.1.1
-    dev: true
 
   /css-what/6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
-    dev: true
 
   /cssom/0.3.8:
     resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
@@ -2208,7 +2208,6 @@ packages:
 
   /cssom/0.5.0:
     resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
-    dev: true
 
   /cssstyle/2.3.0:
     resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
@@ -2365,11 +2364,9 @@ packages:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       entities: 4.4.0
-    dev: true
 
   /domelementtype/2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
-    dev: true
 
   /domexception/4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
@@ -2383,7 +2380,6 @@ packages:
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
-    dev: true
 
   /domutils/3.0.1:
     resolution: {integrity: sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==}
@@ -2391,7 +2387,6 @@ packages:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-    dev: true
 
   /dot-prop/6.0.1:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
@@ -2443,7 +2438,6 @@ packages:
   /entities/4.4.0:
     resolution: {integrity: sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==}
     engines: {node: '>=0.12'}
-    dev: true
 
   /error-ex/1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -3374,7 +3368,6 @@ packages:
 
   /html-escaper/3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
-    dev: true
 
   /htmlparser2/8.0.1:
     resolution: {integrity: sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==}
@@ -3383,7 +3376,6 @@ packages:
       domhandler: 5.0.3
       domutils: 3.0.1
       entities: 4.4.0
-    dev: true
 
   /http-cache-semantics/4.1.0:
     resolution: {integrity: sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==}
@@ -3936,6 +3928,16 @@ packages:
       uhyphen: 0.2.0
     dev: true
 
+  /linkedom/0.14.26:
+    resolution: {integrity: sha512-mK6TrydfFA7phrnp+1j57ycBwFI5bGSW6YXlw9acHoqF+mP/y+FooEYYyniOt5Ot57FSKB3iwmnuQ1UUyNLm5A==}
+    dependencies:
+      css-select: 5.1.0
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 8.0.1
+      uhyphen: 0.2.0
+    dev: false
+
   /listr2/6.4.2:
     resolution: {integrity: sha512-v55SFIDP7SiPEYFeIFGbKW44B4NPpqGEklbAc1EKacMxIqFVXpDlc93e/Q6hE3IgIGRu5870rh5yJc+ESwGUpQ==}
     engines: {node: '>=16.0.0'}
@@ -4339,7 +4341,6 @@ packages:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
     dependencies:
       boolbase: 1.0.0
-    dev: true
 
   /nwsapi/2.2.2:
     resolution: {integrity: sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==}
@@ -5682,7 +5683,6 @@ packages:
 
   /uhyphen/0.2.0:
     resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
-    dev: true
 
   /unique-string/3.0.0:
     resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}


### PR DESCRIPTION
Before, you couldn't click on type names or values. Now, they link to the symbol's definition, even if it's in another API reference.

Notice the underlines in the code blocks, and the links in the inline code.

| Before | After |
| --- | --- |
| <img width="572" alt="Screenshot 2023-05-14 at 9 55 40 AM" src="https://github.com/aklinker1/webext-core/assets/10101283/fc6420b7-71f7-4ae3-a097-b26ab6818979"> | <img width="573" alt="Screenshot 2023-05-14 at 9 56 38 AM" src="https://github.com/aklinker1/webext-core/assets/10101283/4f4852de-2653-40d4-b4f1-0120831a2f0f"> |
