### PR TITLE
fix: Remove webcomponents dependency

### DIFF
--- a/packages/isolated-element/package.json
+++ b/packages/isolated-element/package.json
@@ -48,9 +48,6 @@
     "test:coverage": "vitest run -r src --coverage",
     "compile": "tsc --noEmit"
   },
-  "dependencies": {
-    "@webcomponents/webcomponentsjs": "^2.7.0"
-  },
   "devDependencies": {
     "@vitest/coverage-c8": "^0.24.5",
     "jsdom": "^20.0.3",

--- a/packages/isolated-element/src/index.ts
+++ b/packages/isolated-element/src/index.ts
@@ -1,5 +1,4 @@
 import { CreateIsolatedElementOptions } from './options';
-import '@webcomponents/webcomponentsjs';
 
 export type { CreateIsolatedElementOptions };
 

--- a/packages/isolated-element/src/index.ts
+++ b/packages/isolated-element/src/index.ts
@@ -32,11 +32,6 @@ export async function createIsolatedElement(options: CreateIsolatedElementOption
   const { name, mode = 'closed', css } = options;
 
   // Create the root, parent element
-  try {
-    customElements.define(name, class extends HTMLElement {});
-  } catch {
-    // Custom element already exists, maybe you're trying to mount on a SPA, we don't need to redefine it
-  }
   const parentElement = document.createElement(name);
 
   // Create the shadow and isolated nodes

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,14 +67,11 @@ importers:
   packages/isolated-element:
     specifiers:
       '@vitest/coverage-c8': ^0.24.5
-      '@webcomponents/webcomponentsjs': ^2.7.0
       jsdom: ^20.0.3
       tsconfig: workspace:*
       tsup: ^6.4.0
       typescript: ^4.8.4
       vitest: ^0.24.5
-    dependencies:
-      '@webcomponents/webcomponentsjs': 2.7.0
     devDependencies:
       '@vitest/coverage-c8': 0.24.5_jsdom@20.0.3
       jsdom: 20.0.3


### PR DESCRIPTION
`window.customElements` and `document.attachShadow` APIs are supported by all the browsers.

![image](https://github.com/aklinker1/webext-core/assets/105754605/ec05103d-20aa-4432-95b1-f6e2d0961d9e)

We can get rid of `webcomponents` dependency as it also causes conflicts on pages like `patents.google.com`.