### PR TITLE
fix(storage): Add wrapper function for storage clear

### DIFF
--- a/packages/storage/src/defineExtensionStorage.ts
+++ b/packages/storage/src/defineExtensionStorage.ts
@@ -71,7 +71,9 @@ export function defineExtensionStorage<TSchema extends AnySchema = AnySchema>(
   }
 
   return {
-    clear: storage.clear,
+    clear() { 
+      return storage.clear();
+    },
     getItem(key) {
       return storage.get(key as string).then(res => res[key as string] ?? null);
     },

--- a/packages/storage/src/defineExtensionStorage.ts
+++ b/packages/storage/src/defineExtensionStorage.ts
@@ -71,7 +71,7 @@ export function defineExtensionStorage<TSchema extends AnySchema = AnySchema>(
   }
 
   return {
-    clear() { 
+    clear() {
       return storage.clear();
     },
     getItem(key) {


### PR DESCRIPTION
Safari doesn't have managed storage and it causes extension to crash. 
Managed storage returns undefined for safari so it can't find `browser.storage.managed.clear` throws error