### PR TITLE
fix(isolated-element): Ensure proper bubbling of events from isolated elements

### DIFF
--- a/packages/isolated-element/src/index.test.ts
+++ b/packages/isolated-element/src/index.test.ts
@@ -37,13 +37,13 @@ describe('createIsolatedElement', () => {
     const input = document.createElement('input');
     isolatedElement.append(input);
     document.body.append(parentElement);
-    document.body.append(isolatedElement);
 
     const listener = vi.fn();
     document.body.addEventListener('keyup', listener);
 
     const event = new KeyboardEvent('keyup', {
       bubbles: true,
+      composed: true,
     });
     input.dispatchEvent(event);
 
@@ -61,13 +61,13 @@ describe('createIsolatedElement', () => {
     const input = document.createElement('input');
     isolatedElement.append(input);
     document.body.append(parentElement);
-    document.body.append(isolatedElement);
 
     const listener = vi.fn();
     document.body.addEventListener('keyup', listener);
 
     const event = new KeyboardEvent('keyup', {
       bubbles: true,
+      composed: true,
     });
     input.dispatchEvent(event);
 
@@ -84,7 +84,6 @@ describe('createIsolatedElement', () => {
     const input = document.createElement('input');
     isolatedElement.append(input);
     document.body.append(parentElement);
-    document.body.append(isolatedElement);
 
     const clickListener = vi.fn();
     const keyupListener = vi.fn();
@@ -93,9 +92,11 @@ describe('createIsolatedElement', () => {
 
     const clickEvent = new MouseEvent('click', {
       bubbles: true,
+      composed: true,
     });
     const keyupEvent = new KeyboardEvent('keyup', {
       bubbles: true,
+      composed: true,
     });
     input.dispatchEvent(clickEvent);
     input.dispatchEvent(keyupEvent);


### PR DESCRIPTION
Found this issue during merging it to `wxt`.

Previously, tests for isolated elements might have inaccurately passed by directly appending the isolatedElement to the `document.body`. 

This commit corrects the event propagation mechanism by removing the direct appendage of isolatedElement, ensuring it mimics real-life scenarios more closely. 

Moreover, the 'composed: true' attribute has been added to the events, allowing them to bubble out of the shadow DOM or isolated elements as they would naturally.