### PR TITLE
docs(storage): Fix typo

### DIFF
--- a/docs/guide/storage/typescript.md
+++ b/docs/guide/storage/typescript.md
@@ -54,7 +54,7 @@ favorites.push('https://github.com');
 await localExtSTorage.setItem('favoriteUrls', favorites);
 ```
 
-## Hanlding `null` Correctly
+## Handling `null` Correctly
 
 When using a schema, you'll notice that `getItem` returns `T | null`, but `setItem` requires a non-null value.
 


### PR DESCRIPTION
## Summary
Hey @aklinker1 I found a little typo in the docs while going through it, and decided to fix it. :)
Changed `Hanlding` to `Handling`

Before: 
![image](https://github.com/aklinker1/webext-core/assets/84438186/d74d1887-6f31-40c9-b6d9-3a2298ea1cb2)
After:
![image](https://github.com/aklinker1/webext-core/assets/84438186/e0144981-7902-4124-89e8-440f848ddc66)
