### PR TITLE
fix(messaging): Add verification process for the window messaging

### DIFF
--- a/packages/messaging/src/__tests__/browser/page.test.ts
+++ b/packages/messaging/src/__tests__/browser/page.test.ts
@@ -114,7 +114,7 @@ describe.each<
     );
   });
 
-  it('should throw an error if the responder sends non-serializable data', async () => {
+  it('should throw an error if the responder responds with non-serializable data', async () => {
     interface MessageSchema {
       test(data: string): { getName: () => string };
     }

--- a/packages/messaging/src/custom-event.ts
+++ b/packages/messaging/src/custom-event.ts
@@ -1,6 +1,7 @@
 import { uid } from 'uid';
 import { GenericMessenger, defineGenericMessanging } from './generic';
 import { NamespaceMessagingConfig } from './types';
+import { prepareCustomEventDict } from './utils';
 
 const REQUEST_EVENT = '@webext-core/messaging/custom-events';
 const RESPONSE_EVENT = '@webext-core/messaging/custom-events/response';
@@ -89,8 +90,7 @@ export function defineCustomEventMessaging<
     sendMessage(message) {
       const reqDetail = { message, namespace, instanceId };
       const requestEvent = new CustomEvent(REQUEST_EVENT, {
-        // @ts-expect-error not exist cloneInto types because implemented only in Firefox.
-        detail: typeof cloneInto !== 'undefined' ? cloneInto(reqDetail, window) : reqDetail,
+        detail: prepareCustomEventDict(reqDetail),
       });
       return sendCustomMessage(requestEvent);
     },
@@ -105,14 +105,16 @@ export function defineCustomEventMessaging<
 
         const resDetail = { response, message, instanceId, namespace };
         const responseEvent = new CustomEvent(RESPONSE_EVENT, {
-          // @ts-expect-error not exist cloneInto types because implemented only in Firefox.
-          detail: typeof cloneInto !== 'undefined' ? cloneInto(resDetail, window) : resDetail,
+          detail: prepareCustomEventDict(resDetail),
         });
         window.dispatchEvent(responseEvent);
       };
 
       window.addEventListener(REQUEST_EVENT, requestListener);
       return () => window.removeEventListener(REQUEST_EVENT, requestListener);
+    },
+    verifyMessageData(data) {
+      return structuredClone(data);
     },
   });
 

--- a/packages/messaging/src/utils.ts
+++ b/packages/messaging/src/utils.ts
@@ -1,0 +1,10 @@
+/**
+ * @description In firefox, when dispatching events externally from web-extension, it's necessary to clone all properties of the dictionary. ref: https://github.com/aklinker1/webext-core/pull/70#discussion_r1775031410
+ */
+export function prepareCustomEventDict<T>(
+  data: T,
+  options: { targetScope?: object } = { targetScope: window ?? undefined },
+): T {
+  // @ts-expect-error not exist cloneInto types because implemented only in Firefox.
+  return typeof cloneInto !== 'undefined' ? cloneInto(data, options.targetScope) : data;
+}

--- a/packages/messaging/src/window.ts
+++ b/packages/messaging/src/window.ts
@@ -106,6 +106,9 @@ export function defineWindowMessaging<
       window.addEventListener('message', listener);
       return () => window.removeEventListener('message', listener);
     },
+    verifyMessageData(data) {
+      return structuredClone(data);
+    },
   });
 
   return {


### PR DESCRIPTION
fix #55

## Why cause issue

When sending message between windows, if there is data that cannot be serialized, the response will be `null`. This causes a `No response` error. 

### Solution

It needs to be an error that the user can understand. Add a verification process before the browser sends the message to improve this.