### PR TITLE
feat(messaging): add breakError to the config (#77)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tsconfig.vitest-temp.json
 /.cache
 .output
 .wxt
+.idea

--- a/packages/messaging/src/generic.ts
+++ b/packages/messaging/src/generic.ts
@@ -136,6 +136,10 @@ export function defineGenericMessanging<
         removeRootListener = config.addRootListener(message => {
           // Validate the message object
           if (typeof message.type != 'string' || typeof message.timestamp !== 'number') {
+            // #77 When the message is invalid, we stop processing the message using return or throw an error (default)
+            if (config.breakError) {
+              return;
+            }
             const err = Error(
               `[messaging] Unknown message format, must include the 'type' & 'timestamp' fields, received: ${JSON.stringify(
                 message,

--- a/packages/messaging/src/types.ts
+++ b/packages/messaging/src/types.ts
@@ -77,6 +77,13 @@ export interface BaseMessagingConfig {
    * @default console
    */
   logger?: Logger;
+
+  /**
+   * Whether to break an error when an invalid message is received.
+   *
+   * @default undefined
+   */
+  breakError?: boolean;
 }
 
 export interface NamespaceMessagingConfig extends BaseMessagingConfig {


### PR DESCRIPTION
When the message is invalid, we stop processing the message using return or throw an error (default)