### PR TITLE
docs: Fix typo in `browser.runtime.getURL` call in "@webext-core/messaging" installation docs

### DIFF
--- a/docs/content/messaging/0.installation.md
+++ b/docs/content/messaging/0.installation.md
@@ -171,10 +171,10 @@ script.src = browser.runtime.getURL('/path/to/injected.js');
 document.head.appendChild(script);
 
 script.onload = () => {
-  websiteMessenger.sendMessage("init", { ... });
-}
+  websiteMessenger.sendMessage('init', { ... });
+};
 
-websiteMessenger.onMessage("somethingHappened", (data) => {
+websiteMessenger.onMessage('somethingHappened', (data) => {
   // React to messages from the injected script
 });
 ```
@@ -186,7 +186,7 @@ websiteMessenger.onMessage('init', data => {
   // initialize injected script
 
   // eventually, send data back to the content script
-  websiteMessenger.sendMessage("somethingHappened", { ... });
+  websiteMessenger.sendMessage('somethingHappened', { ... });
 });
 ```
 

--- a/docs/content/messaging/0.installation.md
+++ b/docs/content/messaging/0.installation.md
@@ -167,7 +167,7 @@ Here, we're injecting a script, initializing it with data, and allowing the scri
 import { websiteMessenger } from './website-messenging';
 
 const script = document.createElement('script');
-script.src = browser.runtime.getUrl('/path/to/injected.js');
+script.src = browser.runtime.getURL('/path/to/injected.js');
 document.head.appendChild(script);
 
 script.onload = () => {


### PR DESCRIPTION
fix minor typo: `browser.runtime.getUrl` -> `browser.runtime.getURL`