### PR TITLE
feat(messaging): Make sendMessage data parameter optional

### DIFF
--- a/packages/messaging/src/generic.ts
+++ b/packages/messaging/src/generic.ts
@@ -54,6 +54,12 @@ export interface GenericMessenger<
    */
   sendMessage<TType extends keyof TProtocolMap>(
     type: TType,
+    ...args: GetDataType<TProtocolMap[TType]> extends undefined
+      ? [undefined?, ...TSendMessageArgs]
+      : never
+  ): Promise<GetReturnType<TProtocolMap[TType]>>;
+  sendMessage<TType extends keyof TProtocolMap>(
+    type: TType,
     data: GetDataType<TProtocolMap[TType]>,
     ...args: TSendMessageArgs
   ): Promise<GetReturnType<TProtocolMap[TType]>>;


### PR DESCRIPTION
Current behavior on `sendMessage`:

```typescript
interface ProtocolMap {
  getId: () => string
  getString: (data: number) => string
  getValue: (data: { val: string }) => number
}

const { sendMessage, onMessage } = defineWindowMessaging<ProtocolMap>({
  namespace: 'xxx',
  logger: console,
})

sendMessage('getId') // An argument for 'data' was not provided.
sendMessage('getId', undefined) // ok
```

It looks strange to pass undefined again even it's not actually needed. This PR aims to make the data parameter to be automatically optional.

After the changes:

```typescript
sendMessage('getId') // ok
sendMessage('getId', undefined) // ok
sendMessage('getString') // Argument of type '[]' is not assignable to parameter of type 'never'.
sendMessage('getString', 1) // ok
sendMessage('getValue', { val: '' }) // ok
```

