### PR TITLE
fix(fake-browser): Push new tabs to tabList on creation

### DIFF
--- a/packages/fake-browser/src/apis/tabs.test.ts
+++ b/packages/fake-browser/src/apis/tabs.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fakeBrowser } from '../index';
+
+describe('tabs', () => {
+  beforeEach(fakeBrowser.reset);
+
+  describe('create', () => {
+    it('should create a new tab and add it to tabList', async () => {
+      const newTab = await fakeBrowser.tabs.create({ url: 'https://example.com' });
+
+      expect(newTab).toBeDefined();
+      expect(newTab.id).toBe(1);
+      expect(newTab.url).toBe('https://example.com');
+
+      const tabs = await fakeBrowser.tabs.query({});
+      expect(tabs).toHaveLength(2); // default tab + new tab
+    });
+
+    it('should trigger onCreated event', async () => {
+      const listener = vi.fn();
+      fakeBrowser.tabs.onCreated.addListener(listener);
+
+      const newTab = await fakeBrowser.tabs.create({ url: 'https://example.com' });
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: newTab.id,
+          url: 'https://example.com',
+        }),
+      );
+    });
+  });
+
+  describe('query', () => {
+    it('should filter tabs by windowId', async () => {
+      const window2 = await fakeBrowser.windows.create();
+      const tab1 = await fakeBrowser.tabs.create({ url: 'https://window1.com' });
+      const tab2 = await fakeBrowser.tabs.create({
+        url: 'https://window2.com',
+        windowId: window2.id,
+      });
+
+      const window1Tabs = await fakeBrowser.tabs.query({ windowId: 0 });
+      expect(window1Tabs).toHaveLength(2); // default + tab1
+
+      const window2Tabs = await fakeBrowser.tabs.query({ windowId: window2.id });
+      expect(window2Tabs).toHaveLength(1);
+      expect(window2Tabs[0].url).toBe('https://window2.com');
+    });
+  });
+});

--- a/packages/fake-browser/src/apis/tabs.ts
+++ b/packages/fake-browser/src/apis/tabs.ts
@@ -1,6 +1,6 @@
 import { Tabs, Windows } from 'webextension-polyfill';
 import { BrowserOverrides } from '../types';
-import { windows } from './windows';
+import { windows, DEFAULT_WINDOW } from './windows';
 import { defineEventWithTrigger } from '../utils/defineEventWithTrigger';
 
 type InMemoryTab = Omit<Tabs.Tab, 'active'>;
@@ -23,6 +23,7 @@ const DEFAULT_TAB: InMemoryTab = {
   highlighted: false,
   incognito: false,
   pinned: false,
+  windowId: DEFAULT_WINDOW.id,
 };
 const DEFAULT_NEXT_TAB_ID = 1;
 
@@ -74,12 +75,13 @@ export const tabs: BrowserOverrides['tabs'] = {
     const newTab: InMemoryTab = {
       highlighted: false,
       incognito: false,
-      index: window.tabs?.length ?? 0,
+      index: window?.tabs?.length ?? 0,
       pinned: createProperties.pinned ?? false,
-      windowId: window.id,
+      windowId: window?.id ?? 0,
       id: getNextTabId(),
       url: createProperties.url,
     };
+    tabList.push(newTab);
     const fullTab = mapTab(newTab);
     await onCreated.trigger(fullTab);
     return fullTab;
@@ -122,6 +124,7 @@ export const tabs: BrowserOverrides['tabs'] = {
           res = res && currentWindow.id === tab.windowId;
         if (queryInfo.currentWindow != null && !queryInfo.currentWindow)
           res = res && currentWindow.id !== tab.windowId;
+        if (queryInfo.windowId != null) res = res && tab.windowId === queryInfo.windowId;
         if (queryInfo.discarded != null) res = res && tab.discarded === queryInfo.discarded;
         if (queryInfo.hidden != null) res = res && tab.hidden === queryInfo.hidden;
         if (queryInfo.highlighted != null) res = res && tab.highlighted === queryInfo.highlighted;

--- a/packages/fake-browser/src/apis/windows.ts
+++ b/packages/fake-browser/src/apis/windows.ts
@@ -9,7 +9,7 @@ const onCreated = defineEventWithTrigger<(window: Windows.Window) => void>();
 const onRemoved = defineEventWithTrigger<(windowId: number) => void>();
 const onFocusChanged = defineEventWithTrigger<(windowId: number) => void>();
 
-const DEFAULT_WINDOW: InMemoryWindow = {
+export const DEFAULT_WINDOW: InMemoryWindow = {
   id: 0,
   alwaysOnTop: false,
   incognito: false,


### PR DESCRIPTION
This fixes two issues with tab creation:
* Adds to the tab list so they can be queried (see https://github.com/aklinker1/webext-core/issues/104)
* Makes the tabs query-able by `windowId`