### PR TITLE
feat(messaging): Add global ignore namespaces functionality

### DIFF
--- a/docs/content/messaging/api.md
+++ b/docs/content/messaging/api.md
@@ -312,6 +312,7 @@ interface Message<
   data: GetDataType<TProtocolMap[TType]>;
   type: TType;
   timestamp: number;
+  namespace?: string;
 }
 ```
 
@@ -326,6 +327,8 @@ Contains information about the message received.
 - ***`type: TType`***
 
 - ***`timestamp: number`***<br/>The timestamp the message was sent in MS since epoch.
+
+- ***`namespace?: string`***<br/>Optional namespace for the message. Used by external libraries to identify message sources.
 
 ## `MessageSender`
 

--- a/docs/content/messaging/api.md
+++ b/docs/content/messaging/api.md
@@ -143,6 +143,40 @@ websiteMessenger.onMessage("initInjectedScript", (...) => {
 })
 ```
 
+## `getIgnoreNamespaces`
+
+```ts
+function getIgnoreNamespaces(): string[]
+```
+
+Get the current list of ignored namespace prefixes that apply globally to all messaging instances.
+
+**Returns:** Array of namespace prefixes currently being ignored.
+
+## `setIgnoreNamespaces`
+
+```ts
+function setIgnoreNamespaces(namespaces: string[]): void
+```
+
+Set the global list of namespace prefixes to ignore across all messaging instances. Messages with namespaces starting with any of these prefixes will be filtered out and not processed.
+
+**Important:** This function should be called in both your background script and content scripts to ensure consistent filtering across all contexts.
+
+### Parameters
+
+- ***`namespaces: string[]`***<br/>Array of namespace prefixes to ignore globally.
+
+### Example
+
+```ts
+import { setIgnoreNamespaces } from '@webext-core/messaging';
+
+// Call this in both background.js and content scripts
+// Ignore messages from external SDKs
+setIgnoreNamespaces(['external-sdk:', 'analytics:', 'tracking:']);
+```
+
 ## `ExtensionMessage`
 
 ```ts

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './extension';
+export { setIgnoreNamespaces, getIgnoreNamespaces } from './generic';

--- a/packages/messaging/src/types.ts
+++ b/packages/messaging/src/types.ts
@@ -114,4 +114,8 @@ export interface Message<
    * The timestamp the message was sent in MS since epoch.
    */
   timestamp: number;
+  /**
+   * Optional namespace for the message. Used by external libraries to identify message sources.
+   */
+  namespace?: string;
 }


### PR DESCRIPTION
## Summary

- Adds `setIgnoreNamespaces()` and `getIgnoreNamespaces()` functions for global message filtering
- Messages with namespaces matching any prefix in the ignore list are filtered out globally
- Applies to all messaging instances across background and content scripts
- Includes comprehensive test coverage and API documentation

This feature allows applications to ignore messages from external libraries or browser extensions that may interfere with application messaging by specifying namespace prefixes to filter out globally.

## Usage

```typescript
import { setIgnoreNamespaces } from '@webext-core/messaging';

// Call this in both background.js and content scripts
setIgnoreNamespaces(['external-sdk:', 'analytics:', 'tracking:']);
```

## Test Plan

- [x] Unit tests added for global namespace filtering functionality
- [x] Tests verify messages with ignored namespaces are filtered out  
- [x] Tests verify messages without ignored namespaces are processed normally
- [x] Tests verify namespace management functions work correctly
- [x] All existing tests continue to pass
- [x] API documentation updated with usage examples