### PR TITLE
improved defineWindowMessaging functionality

### DIFF
--- a/docs/content/messaging/0.installation.md
+++ b/docs/content/messaging/0.installation.md
@@ -186,7 +186,10 @@ websiteMessenger.onMessage('init', data => {
   // initialize injected script
 
   // eventually, send data back to the content script
-  websiteMessenger.sendMessage('somethingHappened', { ... });
+  // third and fourth parameter is optional
+  // third parameter is targetOrigin is additional optional value for postMessage which is default to '*'
+  // fourth parameter is reference of window object which is window on which message is passed passed in case of from iframe to Content Script(ie. parent window) it will be window.parent
+  websiteMessenger.sendMessage('somethingHappened', { ... }, '*', window.parent);
 });
 ```
 

--- a/docs/content/messaging/api.md
+++ b/docs/content/messaging/api.md
@@ -19,7 +19,7 @@ interface BaseMessagingConfig {
 
 Shared configuration between all the different messengers.
 
-### Properties
+### Properties 
 
 - ***`logger?: Logger`*** (default: `console`)<br/>The logger to use when logging messages. Set to `null` to disable logging.
 
@@ -35,7 +35,7 @@ interface CustomEventMessage {
 
 Additional fields available on the `Message` from a `CustomEventMessenger`.
 
-### Properties
+### Properties 
 
 - ***`event: CustomEvent`***<br/>The event that was fired, resulting in the message being passed.
 
@@ -153,7 +153,7 @@ interface ExtensionMessage {
 
 Additional fields available on the `Message` from an `ExtensionMessenger`.
 
-### Properties
+### Properties 
 
 - ***`sender: Runtime.MessageSender`***<br/>Information about where the message came from. See
 [`Runtime.MessageSender`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender).
@@ -196,6 +196,12 @@ interface GenericMessenger<
   TMessageExtension,
   TSendMessageArgs extends any[],
 > {
+  sendMessage<TType extends keyof TProtocolMap>(
+    type: TType,
+    ...args: GetDataType<TProtocolMap[TType]> extends undefined
+      ? [data?: undefined, ...args: TSendMessageArgs]
+      : never
+  ): Promise<GetReturnType<TProtocolMap[TType]>>;
   sendMessage<TType extends keyof TProtocolMap>(
     type: TType,
     data: GetDataType<TProtocolMap[TType]>,
@@ -283,7 +289,7 @@ interface Message<
 
 Contains information about the message received.
 
-### Properties
+### Properties 
 
 - ***`id: number`***<br/>A semi-unique, auto-incrementing number used to trace messages being sent.
 
@@ -306,7 +312,7 @@ interface MessageSender {
 
 An object containing information about the script context that sent a message or request.
 
-### Properties
+### Properties 
 
 - ***`tab?: Tabs.Tab`***<br/>The $(ref:tabs.Tab) which opened the connection, if any. This property will <strong>only</strong>
 be present when the connection was opened from a tab (including content scripts), and <strong>only</strong>
@@ -332,7 +338,7 @@ interface NamespaceMessagingConfig extends BaseMessagingConfig {
 }
 ```
 
-### Properties
+### Properties 
 
 - ***`namespace: string`***<br/>A string used to ensure the messenger only sends messages to and listens for messages from
 other messengers of the same type, with the same namespace.
@@ -354,7 +360,7 @@ Used to add a return type to a message in the protocol map.
 
 > Internally, this is just an object with random keys for the data and return types.
 
-### Properties
+### Properties 
 
 - ***`BtVgCTPYZu: TData`***<br/>Stores the data type. Randomly named so that it isn't accidentally implemented.
 
@@ -392,7 +398,7 @@ interface SendMessageOptions {
 
 Options for sending a message to a specific tab/frame
 
-### Properties
+### Properties 
 
 - ***`tabId: number`***<br/>The tab to send a message to
 
@@ -416,7 +422,7 @@ type WindowMessenger<TProtocolMap extends Record<string, any>> =
 ## `WindowSendMessageArgs`
 
 ```ts
-type WindowSendMessageArgs = [targetOrigin?: string];
+type WindowSendMessageArgs = [targetOrigin?: string, targetWindow?: Window];
 ```
 
 For a `WindowMessenger`, `sendMessage` requires an additional argument, the `targetOrigin`. It
@@ -424,6 +430,12 @@ defines which frames inside the page should receive the message.
 
 > See <https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#targetorigin> for more
 details.
+
+message is posted on window which can as per your need like
+parent window in iframe -> window.parent 
+iframe content window -> iframe.contentWindow 
+opener	original window -> window.opener 
+by default global window is used to send mesage
 
 <br/><br/>
 


### PR DESCRIPTION
added optional parameter window for defineWindowMessaging sendMessage function

fixes #90

so currently [Window Messaging](https://webext-core.aklinker1.io/messaging/installation/#window-messaging) works by sending message on window but the reference of window object is based on which window you want to send message to.
like for sending message from injected code in iframe you need to refer `window.parent` and not `window`
