### PR TITLE
fix(types): avoid unbound-method lint errors by adding `this: void`

### DIFF
--- a/packages/messaging/src/generic.ts
+++ b/packages/messaging/src/generic.ts
@@ -53,12 +53,14 @@ export interface GenericMessenger<
    * @param args Different messengers will have additional arguments to configure how a message gets sent.
    */
   sendMessage<TType extends keyof TProtocolMap>(
+    this: void,
     type: TType,
     ...args: GetDataType<TProtocolMap[TType]> extends undefined
       ? [data?: undefined, ...args: TSendMessageArgs]
       : never
   ): Promise<GetReturnType<TProtocolMap[TType]>>;
   sendMessage<TType extends keyof TProtocolMap>(
+    this: void,
     type: TType,
     data: GetDataType<TProtocolMap[TType]>,
     ...args: TSendMessageArgs
@@ -74,6 +76,7 @@ export interface GenericMessenger<
    * @param onReceived The callback executed when a message is received.
    */
   onMessage<TType extends keyof TProtocolMap>(
+    this: void,
     type: TType,
     onReceived: (
       message: Message<TProtocolMap, TType> & TMessageExtension,
@@ -83,7 +86,7 @@ export interface GenericMessenger<
   /**
    * Removes all listeners.
    */
-  removeAllListeners(): void;
+  removeAllListeners(this: void): void;
 }
 
 export function defineGenericMessanging<


### PR DESCRIPTION
This PR addresses the lint errors reported in #82.

Specifically, it adds `this: void` annotations to the `GenericMessenger` interface methods (`sendMessage`, `onMessage`, and `removeAllListeners`) to prevent `typescript-eslint/unbound-method` warnings when destructuring these methods.

These methods do not rely on `this`, so explicitly annotating them with `this: void` ensures they are safely treated as unbound functions.

No runtime behavior is changed; this only affects type checking.

### Before

Destructuring the returned methods results in the following lint error:

```
 ⚠ typescript-eslint(unbound-method): Avoid referencing unbound methods which may cause unintentional scoping of `this`.
    ╭─[packages/messaging/src/extension.test.ts:135:13]
134 │   it('should fully remove the root listener after removeAllListeners was called', async () => {
135 │     const { onMessage, sendMessage, removeAllListeners } = defineExtensionMessaging<ProtocolMap>();
    ·             ─────────
136 │     const input = 'test';
    ╰────
 help: If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.

 ⚠ typescript-eslint(unbound-method): Avoid referencing unbound methods which may cause unintentional scoping of `this`.
    ╭─[packages/messaging/src/extension.test.ts:135:24]
134 │   it('should fully remove the root listener after removeAllListeners was called', async () => {
135 │     const { onMessage, sendMessage, removeAllListeners } = defineExtensionMessaging<ProtocolMap>();
    ·                        ───────────
136 │     const input = 'test';
    ╰────
 help: If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.

 ⚠ typescript-eslint(unbound-method): Avoid referencing unbound methods which may cause unintentional scoping of `this`.
    ╭─[packages/messaging/src/extension.test.ts:135:37]
134 │   it('should fully remove the root listener after removeAllListeners was called', async () => {
135 │     const { onMessage, sendMessage, removeAllListeners } = defineExtensionMessaging<ProtocolMap>();
    ·                                     ──────────────────
136 │     const input = 'test';
    ╰────
 help: If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.
```