### PR TITLE
fix!: Ignore unknown messages instead of throwing an error by default

### DIFF
--- a/packages/messaging/src/extension.test.ts
+++ b/packages/messaging/src/extension.test.ts
@@ -2,6 +2,7 @@ import { describe, it, vi, beforeEach, expect } from 'vitest';
 import { fakeBrowser } from '@webext-core/fake-browser';
 import { ProtocolWithReturn } from './index';
 import { defineExtensionMessaging } from './extension';
+import { defineWorkspace } from 'vitest/config';
 
 /**
  * This is defined in `@webext-core/fake-browser` when there are no `Browser.runtime.onMessage`
@@ -91,17 +92,33 @@ describe('Messaging Wrapper', () => {
     await expect(() => sendMessage('getLength', 'test')).rejects.toThrowError('Some error');
   });
 
-  it('should throw an error when the message is not valid', async () => {
-    const { onMessage } = defineExtensionMessaging<ProtocolMap>();
+  describe('when the message is not valid', () => {
+    it('should ignore it', async () => {
+      const { onMessage } = defineExtensionMessaging<ProtocolMap>();
+      onMessage('getLength', () => {
+        throw Error('Some error');
+      });
+      const res = await fakeBrowser.runtime.sendMessage('hello');
 
-    onMessage('getLength', () => {
-      throw Error('Some error');
+      expect(res).toBeUndefined();
     });
-    const res = fakeBrowser.runtime.sendMessage('hello');
 
-    await expect(res).rejects.toThrowError(
-      "[messaging] Unknown message format, must include the 'type' & 'timestamp' fields, received: \"hello\"",
-    );
+    describe('throwOnUnknownMessageFormat: true', () => {
+      it('should throw an error', async () => {
+        const { onMessage } = defineExtensionMessaging<ProtocolMap>({
+          throwOnUnknownMessageFormat: true,
+        });
+
+        onMessage('getLength', () => {
+          throw Error('Some error');
+        });
+        const res = fakeBrowser.runtime.sendMessage('hello');
+
+        await expect(res).rejects.toThrowError(
+          "[messaging] Unknown message format, must include the 'type' & 'timestamp' fields, received: \"hello\"",
+        );
+      });
+    });
   });
 
   it('should throw an error when no listeners have been setup', async () => {

--- a/packages/messaging/src/extension.test.ts
+++ b/packages/messaging/src/extension.test.ts
@@ -2,7 +2,6 @@ import { describe, it, vi, beforeEach, expect } from 'vitest';
 import { fakeBrowser } from '@webext-core/fake-browser';
 import { ProtocolWithReturn } from './index';
 import { defineExtensionMessaging } from './extension';
-import { defineWorkspace } from 'vitest/config';
 
 /**
  * This is defined in `@webext-core/fake-browser` when there are no `Browser.runtime.onMessage`

--- a/packages/messaging/src/generic.ts
+++ b/packages/messaging/src/generic.ts
@@ -145,7 +145,7 @@ export function defineGenericMessanging<
         removeRootListener = config.addRootListener(message => {
           // Validate the message object
           if (typeof message.type != 'string' || typeof message.timestamp !== 'number') {
-            if (config.throwOnInvalidMessage) {
+            if (config.throwOnUnknownMessageFormat) {
               const err = Error(
                 `[messaging] Unknown message format, must include the 'type' & 'timestamp' fields, received: ${JSON.stringify(
                   message,

--- a/packages/messaging/src/generic.ts
+++ b/packages/messaging/src/generic.ts
@@ -145,17 +145,18 @@ export function defineGenericMessanging<
         removeRootListener = config.addRootListener(message => {
           // Validate the message object
           if (typeof message.type != 'string' || typeof message.timestamp !== 'number') {
-            // #77 When the message is invalid, we stop processing the message using return or throw an error (default)
-            if (config.breakError) {
+            if (config.throwOnInvalidMessage) {
+              const err = Error(
+                `[messaging] Unknown message format, must include the 'type' & 'timestamp' fields, received: ${JSON.stringify(
+                  message,
+                )}`,
+              );
+              config.logger?.error(err);
+              throw err;
+            } else {
+              // Ignore messages from other messaging libraries
               return;
             }
-            const err = Error(
-              `[messaging] Unknown message format, must include the 'type' & 'timestamp' fields, received: ${JSON.stringify(
-                message,
-              )}`,
-            );
-            config.logger?.error(err);
-            throw err;
           }
 
           // Execute the type's listener

--- a/packages/messaging/src/types.ts
+++ b/packages/messaging/src/types.ts
@@ -85,7 +85,7 @@ export interface BaseMessagingConfig {
    *
    * @default false
    */
-  throwOnInvalidMessage?: boolean;
+  throwOnUnknownMessageFormat?: boolean;
 }
 
 export interface NamespaceMessagingConfig extends BaseMessagingConfig {

--- a/packages/messaging/src/types.ts
+++ b/packages/messaging/src/types.ts
@@ -79,11 +79,13 @@ export interface BaseMessagingConfig {
   logger?: Logger;
 
   /**
-   * Whether to break an error when an invalid message is received.
+   * When a message is received that doesn't follow `@webext-core/messaging`'s format, it is ignored.
    *
-   * @default undefined
+   * Set this value to true to throw an error instead of ignoring it.
+   *
+   * @default false
    */
-  breakError?: boolean;
+  throwOnInvalidMessage?: boolean;
 }
 
 export interface NamespaceMessagingConfig extends BaseMessagingConfig {


### PR DESCRIPTION
BREAKING CHANGE: Changed the default behavior when a message is received with an unknown format (like from another messaging library). Before, it would throw an error. Now, it is silently ignored so other messaging libraries have a chance to handle it themselves. The old `breakError` option has been removed (if you set it to `breakError: true`, you can remove the option, it's now the default). To continue throwing errors, set `throwOnUnknownMessageFormat: true`.