### PR TITLE
fix: Drop `uid` for simple random ID

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -85,7 +85,6 @@
       "version": "2.3.0",
       "dependencies": {
         "serialize-error": "^11.0.0",
-        "uid": "^2.0.2",
         "webextension-polyfill": "^0.10.0",
       },
       "devDependencies": {
@@ -270,8 +269,6 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
-
-    "@lukeed/csprng": ["@lukeed/csprng@1.1.0", "", {}, "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="],
 
     "@mswjs/interceptors": ["@mswjs/interceptors@0.35.2", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-bYs0FBd5rDu6pMID08VMnkB0/HpHsHt6+8X7TM0YSDF29tiXNZhffdaRxiazKY6TIboHMX+s7ZBejNkaKlqZVg=="],
 
@@ -1350,8 +1347,6 @@
     "ufo": ["ufo@1.5.4", "", {}, "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ=="],
 
     "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
-
-    "uid": ["uid@2.0.2", "", { "dependencies": { "@lukeed/csprng": "^1.0.0" } }, "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g=="],
 
     "undici-types": ["undici-types@6.13.0", "", {}, "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg=="],
 

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -65,7 +65,6 @@
   },
   "dependencies": {
     "serialize-error": "^11.0.0",
-    "uid": "^2.0.2",
     "webextension-polyfill": "^0.10.0"
   },
   "devDependencies": {

--- a/packages/messaging/src/custom-event.ts
+++ b/packages/messaging/src/custom-event.ts
@@ -1,7 +1,6 @@
-import { uid } from 'uid';
 import { GenericMessenger, defineGenericMessanging } from './generic';
 import { NamespaceMessagingConfig } from './types';
-import { prepareCustomEventDict } from './utils';
+import { prepareCustomEventDict, createId } from './utils';
 
 const REQUEST_EVENT = '@webext-core/messaging/custom-events';
 const RESPONSE_EVENT = '@webext-core/messaging/custom-events/response';
@@ -61,7 +60,7 @@ export function defineCustomEventMessaging<
   TProtocolMap extends Record<string, any> = Record<string, any>,
 >(config: CustomEventMessagingConfig): CustomEventMessenger<TProtocolMap> {
   const namespace = config.namespace;
-  const instanceId = uid();
+  const instanceId = createId();
 
   const removeAdditionalListeners: Array<() => void> = [];
 

--- a/packages/messaging/src/utils.ts
+++ b/packages/messaging/src/utils.ts
@@ -8,3 +8,7 @@ export function prepareCustomEventDict<T>(
   // @ts-expect-error not exist cloneInto types because implemented only in Firefox.
   return typeof cloneInto !== 'undefined' ? cloneInto(data, options.targetScope) : data;
 }
+
+export function createId(): string {
+  return Math.random().toString(36).substring(2, 10);
+}

--- a/packages/messaging/src/window.ts
+++ b/packages/messaging/src/window.ts
@@ -1,6 +1,6 @@
-import { uid } from 'uid';
 import { GenericMessenger, defineGenericMessanging } from './generic';
 import { NamespaceMessagingConfig, Message } from './types';
+import { createId } from './utils';
 
 const REQUEST_TYPE = '@webext-core/messaging/window';
 const RESPONSE_TYPE = '@webext-core/messaging/window/response';
@@ -60,7 +60,7 @@ export function defineWindowMessaging<
   TProtocolMap extends Record<string, any> = Record<string, any>,
 >(config: WindowMessagingConfig): WindowMessenger<TProtocolMap> {
   const namespace = config.namespace;
-  const instanceId = uid();
+  const instanceId = createId();
 
   let removeAdditionalListeners: Array<() => void> = [];
 


### PR DESCRIPTION
One less dependency, the ID doesn't need to be secure or exceptionally random where it's used in the messaging library.