### PR TITLE
Add build step in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Update NPM for Provence
         run: sudo npm i -g npm@latest
 
+      - name: Build package
+        run: bun run --cwd packages/${{ inputs.package }} build
+
       - name: Bump and Release
         uses: aklinker1/zero-changelog/actions/release@3c6754fb743552a2694a1a8efcc50bd4a67299ad # 0.1.10
         with:


### PR DESCRIPTION
Fixes #143 

This builds the code so that it exists in the release.

It may also be a good idea to add a check step to make absolutely sure:

```
- name: Verify built output
  working-directory: packages/${{ inputs.package }}
  run: npm pack --dry-run 2>&1 | grep -q 'lib/index'
```