### PR TITLE
ci: Cache playwright browser install

### DIFF
--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -1,0 +1,23 @@
+name: Install Playwright Browsers
+description: Install and cache browsers installed via playwright install --with-deps
+runs:
+  using: composite
+  steps:
+    - name: Store Playwright's Version
+      run: |
+        PLAYWRIGHT_VERSION=$(bun pm ls | grep playwright | sed 's/.*@//')
+        echo "Playwright's Version: $PLAYWRIGHT_VERSION"
+        echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Cache Playwright Browsers for Playwright's Version
+      id: cache-playwright-browsers
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}
+
+    - name: Setup Playwright
+      if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+      run: npx playwright install --with-deps
+      shell: bash

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,8 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup
-      - name: Install Playwright Browsers
-        run: bun x playwright install --with-deps
+      - uses: ./.github/actions/install-playwright
       - run: |
           bun run --cwd packages/fake-browser test:coverage
           bun run --cwd packages/isolated-element test:coverage


### PR DESCRIPTION
This takes the install step from [30-60 seconds](https://github.com/aklinker1/webext-core/actions/runs/26099870784/job/76747592023) down to [6 seconds](https://github.com/aklinker1/webext-core/actions/runs/26099870784/job/76748251953).

The whole tests job went from [1m 17s](https://github.com/aklinker1/webext-core/actions/runs/26099870784/attempts/1) down to [42s](https://github.com/aklinker1/webext-core/actions/runs/26099870784). As the slowest job, this will speed up PR checks nicely.

<img width="785" height="119" alt="image" src="https://github.com/user-attachments/assets/28eaad77-d6e0-46d2-8796-554c3e1fa086" />
